### PR TITLE
CoeFont Editorのブロックヘッダルートclassが変わったので修正

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -2,7 +2,7 @@ function getName(blockRoot) {
   if (!blockRoot) {
     return undefined;
   }
-  const blockHeader = blockRoot.querySelector('[class*=Block_blockHeaderRoot__]');
+  const blockHeader = blockRoot.querySelector('[class*=BlockHeader_desktopBlockHeaderRoot__], [class*=BlockHeader_mobileBlockHeaderRoot__]');
   if (!blockHeader) {
     return undefined;
   }


### PR DESCRIPTION
## 概要
直近でブロックのClassが変わる変更がリリースされたらしいので、セレクタを変更した。一応幅狭UIにも対応させています。

## 変更箇所
content-script.js:5
```diff
-   const blockHeader = blockRoot.querySelector('[class*=Block_blockHeaderRoot__]');
+   const blockHeader = blockRoot.querySelector('[class*=BlockHeader_desktopBlockHeaderRoot__], [class*=BlockHeader_mobileBlockHeaderRoot__]');
  if (!blockHeader) {
    return undefined;
```
